### PR TITLE
Make the modal more intuitive.

### DIFF
--- a/pages/campaigns/_id/index.vue
+++ b/pages/campaigns/_id/index.vue
@@ -343,7 +343,7 @@
                   :disabled="!canUserQualify"
                   @click.prevent="joinCampaignPopup = true"
                 >
-                  Qualify
+                  Enter Task
                 </button>
                 <button
                   v-else-if="activeCampaignBatches.reduce((a,b) => a + b.num_tasks, 0) - activeCampaignBatches.reduce((a,b) => a + b.real_tasks_done, 0) > 0 && !userReservation"


### PR DESCRIPTION
Instead of having the user see 'Qualify' I updated this to say 'Enter Task' to clear confusion. 