### PR TITLE
Added progress bar in reservations

### DIFF
--- a/components/ProgressBar.vue
+++ b/components/ProgressBar.vue
@@ -26,12 +26,16 @@ const props = defineProps<{
   position: relative;
   width: 100%;
   background-color: #f1f1f1;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
 }
 
 .bar {
   width: 0;
-  height: 100%;
+  height: 10px;
   background-color: #4caf50;
-  transition: 0.5s;
+  /* height: 100%; */
+  border-radius: 10px;
+  transition: 0.5s
 }
 </style>

--- a/components/ReservationCard.vue
+++ b/components/ReservationCard.vue
@@ -6,13 +6,17 @@
   >
     <div class="reservation-container">
       <div>
-      <span class="started-on">
-        started {{ formatDateStringToTimeAgo(props.reservedOn) }}</span>
-      <h2 class="card-title">
-        <span>{{ campaign.info?.title }}</span>
-      </h2>
-      <p>{{ campaign.info?.description }}</p>
-    </div>
+        <span class="started-on">
+          started {{ formatDateStringToTimeAgo(props.reservedOn) }}</span>
+        <h2 class="card-title">
+          <span>{{ campaign.info?.title }}</span>
+        </h2>
+        <p>{{ campaign.info?.description }}</p>
+      </div>
+      <ProgressBar
+        :reverse="false"
+        :progress= getProgress(campaign)
+      />
       <ForceButton
         :is-loading="loading"
         class="button"
@@ -58,6 +62,14 @@ const loadFromCache = async () => {
 		return found ? (cachedCampaign.value = found) : null;
 	}
 };
+
+//this is temporary until the logic is added to "useCampaigns"
+const getProgress = (campaign) => {
+  if (((campaign.reservations_done) / campaign.total_tasks) > 1) {
+    return 100
+  }
+  return (campaign.reservations_done / campaign.total_tasks)*100
+}
 
 onMounted(async () => {
 	// try to load the corresponding campaign from the cache


### PR DESCRIPTION
This PR adds the progress bar for reservations using basic logic for getting _tasksAvailable_. 

**Note** This "logic" will be changed in the future once, as stated by @Jeffrieh in #247 . The logic for _tasksAvailable_ will be "integrated with the _useCampaigns_ composable".

Resolves #245.